### PR TITLE
修复悬浮球在部分手机被通知栏部分被遮挡的问题

### DIFF
--- a/floatingview/src/main/java/com/feiyu/floatingview/weight/FloatingView.java
+++ b/floatingview/src/main/java/com/feiyu/floatingview/weight/FloatingView.java
@@ -82,7 +82,9 @@ public class FloatingView extends RelativeLayout {
         mFloatBallParams.flags = mFloatBallParams.flags
                 | WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH
                 | WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
-                | WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE;
+                | WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+            //避免悬浮球被通知栏部分遮挡
+                |WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
         mFloatBallParams.dimAmount = 0.2f;
 
 //      mFloatBallParams.type = WindowManager.LayoutParams.TYPE_SYSTEM_ALERT;


### PR DESCRIPTION
增加悬浮球的显示范围，避免悬浮球在部分手机被通知栏部分遮挡
问题出现的手机为：小米9，redmi k30pro
横屏必现